### PR TITLE
Moving front-page text from main site into docs

### DIFF
--- a/docs/contact/contact-rcpch.md
+++ b/docs/contact/contact-rcpch.md
@@ -1,0 +1,6 @@
+---
+title: Contact us
+reviewers: Dr Anchit Chandran
+---
+
+# Contact Page

--- a/docs/development/docker-setup.md
+++ b/docs/development/docker-setup.md
@@ -3,7 +3,7 @@ title: Docker development
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 ---
 
-To simplify the development environment setup and provide greater consistency between development and production environments, we have packaged the application as a Docker image and we used `docker compose` to set up the app and database containers in development. This means that you don't need to worry about conflicts of Python versions, Python library versions, or Python virtual environments. Everything is specified and isolated inside the Docker container.
+To simplify the development environment setup and provide greater consistency between development and production environments, we have packaged the application as a Docker image and we used `docker compose` to set up the app and database containers in development. This means you don't need to worry about conflicts of Python versions, Python library versions, or Python virtual environments. Everything is specified and isolated inside the Docker container.
 
 ## Setup for development using Docker Compose
 

--- a/docs/development/docker-setup.md
+++ b/docs/development/docker-setup.md
@@ -3,7 +3,7 @@ title: Docker development
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 ---
 
-In order to simplify the development environment setup and provide greater consistency between development and production environments, we have packaged the application as a Docker image and we used `docker compose` to set up the app and database containers in development. This means that you don't need to worry about conflicts of Python versions, Python library versions, or Python virtual environments. Everything is specified and isolated inside the Docker container.
+To simplify the development environment setup and provide greater consistency between development and production environments, we have packaged the application as a Docker image and we used `docker compose` to set up the app and database containers in development. This means that you don't need to worry about conflicts of Python versions, Python library versions, or Python virtual environments. Everything is specified and isolated inside the Docker container.
 
 ## Setup for development using Docker Compose
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,6 @@ title: Introduction to the RCPCH Epilepsy12 Audit Platform
 author: Dr Marcus Baw
 ---
 
-<p align="center">
-    <img align="center" src="../_assets/_images/epilepsy12-logo-1.png" width='300px'/>
-</p>
-
 ## Introduction
 
 The RCPCH Audit Engine is a generic framework for national clinical audits. Its first deployment is as a new platform for the RCPCH's established Epilepsy12 audit, a national audit for childhood epilepsies which has been in place since 2009, but it is designed so as to be reusable for other audits in the future.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,13 @@ author: Dr Marcus Baw
 
 ## Introduction
 
-The RCPCH Audit Engine is a generic framework for national clinical audits. Its first deployment is as a new platform for the RCPCH's established Epilepsy12 audit, a national audit for childhood epilepsies which has been in place since 2009, but it is designed so as to be reusable for other audits in the future.
+The RCPCH Audit Engine is a generic framework for national clinical audits. Its first deployment is as a new platform for the RCPCH's established Epilepsy12 audit, but it is designed so as to be reusable for other audits in the future.
 
-National clinical audits are there to collect diagnosis and care process data on patient cohorts with a diagnosis in common, nationally, to benchmark the standard of care and feed back to care-giving organisations about their performance. They are a way to make sure that clinics are meeting centrally-set standards, and give clinics feedback on how they are doing. Most national audits such as Epilepsy12 are commissioned by NHS England.
+National clinical audits collect diagnosis and care process data on patient cohorts with a diagnosis in common, nationally, to benchmark the standard of care and feed back to care-giving organisations about their performance. They are a way to make sure that clinics are meeting centrally-set standards, and give clinics feedback on how they are doing. Most national audits such as Epilepsy12 are commissioned by NHS England.
+
+## Epilepsy 12
+
+Epilepsy12 (The UK collaborative clinical audit of health care for children and young people with suspected epileptic seizures) is a national clinical audit established in 2009 and has the continued aim of helping epilepsy services, and those who commission health services, to measure and improve the quality of care for children and young people with seizures and epilepsies. As per rounds 1 - 3 of the audit the audit is overseen by a project board and a dedicated project team within the RCPCH.
 
 ## Stated Aims of the Audit
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,10 @@ National clinical audits are there to collect diagnosis and care process data on
 * (a) Comprehensive care plan that is updated and agreed with the patient, and (b) Documented evidence of all key elements of care planning content.
 * Record of a school individual health care plan.
 
+## National Data Opt Out Implementation (England only)
+
+The Epilepsy12 audit is now exempt from the NHS National Data Opt-Out. Healthcare providers in England no longer need to screen patients against the opt-out list prior to entering their data. Patients can still opt out of Epilepsy12 specifically by contacting their clinical team. You can indicate this in the first year of care form and the record will be deleted. Please take a look at our methodology and data submission page for more information.
+
 ## Feedback and Feature Requests
 
 ## Citation of the Epilepsy12 audit in academic publications

--- a/docs/parents/introduction.md
+++ b/docs/parents/introduction.md
@@ -2,3 +2,11 @@
 title: Parent's Guide
 author: Dr Marcus Baw
 ---
+
+## Childhood Epilepsy
+
+Epilepsy affects around one in every 200 children and young people in the UK (aged 18 and under). The condition is one of the most common significant long-term health conditions of childhood.
+
+Epileptic seizures can happen in any part of the brain cortex and what happens depends on where in the brain the seizure is happening. Seizures can be distressing but it's not just the seizures that are the problem. Children and young people may experience issues with learning, behaviour and emotions.
+
+Epilepsy can have a huge impact on children and families. That's why children and parents need support and guidance from healthcare professionals throughout the stages of diagnosis and treatment.


### PR DESCRIPTION
- moved the front page text from main site into docs

Fixes [#278](https://github.com/rcpch/rcpch-audit-engine/issues/278)