### PR TITLE
Create user-group-permissions.md

### DIFF
--- a/docs/clinician-users/user-group-permissions.md
+++ b/docs/clinician-users/user-group-permissions.md
@@ -1,0 +1,24 @@
+---
+title: User Groups
+reviewers: 
+---
+
+## User Groups
+
+There are three user groups for staff working in Trusts/Health Boards, with varying permissions. 
+1. Lead Clinician
+  - Can create, edit and delete users within their Trust/Health Board
+  - Can create, edit, and delete patients within their Trust/Health Board
+  - Can create, edit, and delete patient audit records
+2. Clinician
+  - Can view users within their Trust/Health Board
+  - Can create, edit and delete patients within their Trust/Health Boards
+  - Can create, edit and delete patient audit records
+3. Administrator
+  - Can view users within their Trust/Health Board
+  - Can create and edit patients within their Trust/Health Board
+  - Can view patient audit records
+
+These user groups are linked to one or multiple Trust/Health Boards which are providing epilepsy care to children and/or young people. Users are assigned to an 'organisation', which is defined as individual hospitals/sites/community services within one Trust/Health Board. 
+
+Users will only have access to the data relating to their own Trust/Health Board. They may see children and users at other organisations within their Trust/Health Board.


### PR DESCRIPTION
added new page with summary of user permissions for clinicians. Should be useful for lead clinicians who want to add new users.

I've not assigned a reviewer.